### PR TITLE
Fixed Self Closing Render Tags

### DIFF
--- a/view/adminhtml/web/template/content-type/vendor-quote/default/preview.html
+++ b/view/adminhtml/web/template/content-type/vendor-quote/default/preview.html
@@ -1,5 +1,5 @@
 <div attr="data.main.attributes" ko-style="data.main.style" class="pagebuilder-content-type pagebuilder-vendor-quote" css="data.main.css" event="{ mouseover: onMouseOver, mouseout: onMouseOut }, mouseoverBubble: false">
-    <render args="getOptions().template"/>
+    <render args="getOptions().template"></render>
     <div class="quote-wrapper">
         <div class="quote-icon"></div>
         <div class="quote" attr="data.quote.attributes" css="data.quote.css" data-bind="liveEdit: { field: 'quote', placeholder: $t('Edit Quote Text') }"></div>

--- a/view/adminhtml/web/template/content-type/vendor-quote/picture-quote/preview.html
+++ b/view/adminhtml/web/template/content-type/vendor-quote/picture-quote/preview.html
@@ -1,5 +1,5 @@
 <div attr="data.main.attributes" ko-style="data.main.style" class="pagebuilder-content-type pagebuilder-vendor-quote" css="data.main.css" event="{ mouseover: onMouseOver, mouseout: onMouseOut }, mouseoverBubble: false">
-    <render args="getOptions().template"/>
+    <render args="getOptions().template"></render>
     <div class="quote-image">
         <img if="data.quote_image.attributes().src" attr="data.quote_image.attributes" ko-style="data.quote_image.style" css="data.quote_image.css" />
         <div class="quote-image-placeholder" ifnot="data.quote_image.attributes().src"></div>


### PR DESCRIPTION
Support for Magento 2.4.5 where  jquery-migrate won't allow self closing tags. 